### PR TITLE
Add Fastlane and GitHub Actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Ruby and Bundler
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7' # Specify a Ruby version compatible with Fastlane and your project
+        bundler-cache: true # Automatically runs bundle install and caches gems
+
+    - name: Build with Fastlane
+      run: bundle exec fastlane build

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,6 @@ default_platform(:ios)
 platform :ios do
   desc "Build the Spacequest app"
   lane :build do
-    gym(scheme: "Spacequest")
+    gym(scheme: "Spacequest", xcargs: "-allowProvisioningUpdates")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,8 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Build the Spacequest app"
+  lane :build do
+    gym(scheme: "Spacequest")
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,6 @@ default_platform(:ios)
 platform :ios do
   desc "Build the Spacequest app"
   lane :build do
-    gym(scheme: "Spacequest", xcargs: "-allowProvisioningUpdates")
+    gym(scheme: "Spacequest", xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO")
   end
 end


### PR DESCRIPTION
This commit introduces Fastlane for building the iOS project and integrates it with GitHub Actions.

- A `Gemfile` is added with `fastlane` as a dependency.
- A `fastlane/Fastfile` is created with a `build` lane that uses `gym` to build the `Spacequest` scheme.
- A GitHub Actions workflow in `.github/workflows/main.yml` is set up to:
    - Trigger on every push.
    - Checkout the code.
    - Set up Ruby and Bundler.
    - Install gems.
    - Run `bundle exec fastlane build` to build the application.

This will automate the build process for every push to the repository.